### PR TITLE
Fixed Nullability issue in WorldManager, fixes #45

### DIFF
--- a/src/main/kotlin/me/luna/trollhack/manager/managers/WorldManager.kt
+++ b/src/main/kotlin/me/luna/trollhack/manager/managers/WorldManager.kt
@@ -59,7 +59,8 @@ object WorldManager : Manager(), IWorldEventListener {
 
     }
 
-    override fun playEvent(player: EntityPlayer, type: Int, blockPosIn: BlockPos, data: Int) {
+    @Suppress("WRONG_NULLABILITY_FOR_JAVA_OVERRIDE") // is Nullable in World.playEvent
+    override fun playEvent(player: EntityPlayer?, type: Int, blockPosIn: BlockPos, data: Int) {
 
     }
 }


### PR DESCRIPTION
While not Nullable in IWorldEventListener, World.playEvent actually marks the EntityPlayer argument as Nullable.

Edit: Closes #45 